### PR TITLE
Changed name of output zip to include mod id and version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
-/node_modules/
+# Editor Configs
 /.idea/
+
+# Dependencies
+/node_modules/
+
+# OS Files
+.DS_Store
+
+# Built files
+/dist/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,28 +2,30 @@ const gulp = require('gulp');
 const del = require('del');
 const zip = require('gulp-zip');
 
+const config = require('./build/config.json')
+
 gulp.task('delDist', () => {
     return del(['dist']);
 });
 
+gulp.task('delTemp', () => {
+    return del(['temp']);
+});
+
 gulp.task('moveAssets', () => {
     return gulp.src('public/assets/**/*')
-        .pipe(gulp.dest('dist/assets'));
+        .pipe(gulp.dest('temp/assets'));
 });
 
 gulp.task('moveConfigAndMod', () => {
     return gulp.src(['build/config.json', 'public/js/mod.js'])
-        .pipe(gulp.dest('dist'));
+        .pipe(gulp.dest('temp'));
 });
 
 gulp.task('zipFiles', () => {
-    return gulp.src('dist/**')
-        .pipe(zip('mod.zip'))
+    return gulp.src('temp/**')
+        .pipe(zip(`${config.id}-${config.version}`))
         .pipe(gulp.dest('dist'));
 });
 
-gulp.task('deleteFiles', () => {
-    return del(['dist/**/*', '!dist/mod.zip']);
-});
-
-gulp.task('default', gulp.series('delDist', 'moveAssets', 'moveConfigAndMod', 'zipFiles', 'deleteFiles'));
+gulp.task('default', gulp.series('delDist', 'moveAssets', 'moveConfigAndMod', 'zipFiles', 'delTemp'));


### PR DESCRIPTION
First, I just wanted to say I've been enjoying your game and I'm really happy you decide to work on modding tools for it!

--

I feel it would be better if this template produced a `.zip` file named something more like: `MyMod-0.1.0.zip`

This is consistent with how your existing mod packages are named, and make the zip file immediately ready for sharing.

This CL adjusts a couple things to make this possible:
- Gulp assembles the mod files in a temporary `temp/` directory instead of in `dist/`. This makes it easier to just delete the whole directory instead of selectively excluding the built file.
- `gulpfile.js` imports `config.json` for use in naming the package. I feel this is reasonable as a build system should make use of the existing configuration files.
- Added `/dist/` to `.gitignore`. Just so that users cannot accidentally commit their .zip files to the repo.
- Also added some comments to the `.gitignore`.

Let me know what you think. Happy to make changes.